### PR TITLE
Fixed basic spring boot pipeline

### DIFF
--- a/basic-spring-boot/Jenkinsfile
+++ b/basic-spring-boot/Jenkinsfile
@@ -13,7 +13,7 @@ node('master') {
   env.TOKEN = readFile('/var/run/secrets/kubernetes.io/serviceaccount/token').trim()
   env.OC_CMD = "oc --token=${env.TOKEN} --server=${ocpApiServer} --certificate-authority=/run/secrets/kubernetes.io/serviceaccount/ca.crt --namespace=${env.NAMESPACE}"
 
-  env.APP_NAME = "${env.JOB_NAME}".replaceAll(/-?pipeline-?/, '').replaceAll(/-?${env.NAMESPACE}-?/, '')
+  env.APP_NAME = "${env.JOB_NAME}".replaceAll(/-?pipeline-?/, '').replaceAll(/-?${env.NAMESPACE}-?/, '').replaceAll("/", '')
   def projectBase = "${env.NAMESPACE}".replaceAll(/-build/, '')
   env.STAGE1 = "${projectBase}-dev"
   env.STAGE2 = "${projectBase}-stage"

--- a/basic-spring-boot/applier/params/build-dev
+++ b/basic-spring-boot/applier/params/build-dev
@@ -1,4 +1,4 @@
 APPLICATION_NAME=spring-rest
 NAMESPACE=basic-spring-boot-build
-SOURCE_REPOSITORY_URL=https://github.com/etsauer/container-pipelines.git
-SOURCE_REPOSITORY_REF=applier-enable
+SOURCE_REPOSITORY_URL=https://github.com/redhat-cop/container-pipelines.git
+SOURCE_REPOSITORY_REF=master

--- a/basic-spring-boot/applier/templates/build.yml
+++ b/basic-spring-boot/applier/templates/build.yml
@@ -13,6 +13,69 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
+    annotations:
+      openshift.io/display-name: Red Hat OpenJDK 8
+      openshift.io/image.dockerRepositoryCheck: 2018-04-06T20:39:19Z
+      openshift.io/provider-display-name: Red Hat, Inc.
+      version: 1.4.8
+    name: redhat-openjdk18-openshift
+    namespace: openshift
+  spec:
+    tags:
+    - annotations:
+        description: Build and run Java applications using Maven and OpenJDK 8.
+        iconClass: icon-rh-openjdk
+        openshift.io/display-name: Red Hat OpenJDK 8
+        sampleContextDir: undertow-servlet
+        sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+        supports: java:8
+        tags: builder,java,openjdk,hidden
+        version: "1.0"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/redhat-openjdk-18/redhat-openjdk18-openshift:1.0
+      generation: 2
+      importPolicy: {}
+      name: "1.0"
+      referencePolicy:
+        type: Source
+    - annotations:
+        description: Build and run Java applications using Maven and OpenJDK 8.
+        iconClass: icon-rh-openjdk
+        openshift.io/display-name: Red Hat OpenJDK 8
+        sampleContextDir: undertow-servlet
+        sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+        supports: java:8
+        tags: builder,java,openjdk
+        version: "1.1"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/redhat-openjdk-18/redhat-openjdk18-openshift:1.1
+      generation: 2
+      importPolicy: {}
+      name: "1.1"
+      referencePolicy:
+        type: Source
+    - annotations:
+        description: Build and run Java applications using Maven and OpenJDK 8.
+        iconClass: icon-rh-openjdk
+        openshift.io/display-name: Red Hat OpenJDK 8
+        sampleContextDir: undertow-servlet
+        sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+        supports: java:8
+        tags: builder,java,openjdk
+        version: "1.2"
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/redhat-openjdk-18/redhat-openjdk18-openshift:1.2
+      generation: 2
+      importPolicy: {}
+      name: "1.2"
+      referencePolicy:
+        type: Source
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}

--- a/basic-spring-boot/applier/templates/build.yml
+++ b/basic-spring-boot/applier/templates/build.yml
@@ -20,7 +20,7 @@ objects:
       openshift.io/provider-display-name: Red Hat, Inc.
       version: 1.4.8
     name: redhat-openjdk18-openshift
-    namespace: openshift
+    namespace: ${IMAGE_STREAM_NAMESPACE}
   spec:
     tags:
     - annotations:

--- a/basic-spring-boot/applier/templates/build.yml
+++ b/basic-spring-boot/applier/templates/build.yml
@@ -12,6 +12,8 @@ metadata:
 objects:
 - apiVersion: v1
   kind: ImageStream
+  labels:
+    xpaas: 1.4.8
   metadata:
     annotations:
       openshift.io/display-name: Red Hat OpenJDK 8
@@ -29,15 +31,11 @@ objects:
         sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
         supports: java:8
         tags: builder,java,openjdk,hidden
-        version: "1.0"
+        version: '1.0'
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/redhat-openjdk18-openshift:1.0
-      generation: 2
-      importPolicy: {}
-      name: "1.0"
-      referencePolicy:
-        type: Source
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.0
+      name: '1.0'
     - annotations:
         description: Build and run Java applications using Maven and OpenJDK 8.
         iconClass: icon-rh-openjdk
@@ -46,15 +44,11 @@ objects:
         sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
         supports: java:8
         tags: builder,java,openjdk
-        version: "1.1"
+        version: '1.1'
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/redhat-openjdk18-openshift:1.1
-      generation: 2
-      importPolicy: {}
-      name: "1.1"
-      referencePolicy:
-        type: Source
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.1
+      name: '1.1'
     - annotations:
         description: Build and run Java applications using Maven and OpenJDK 8.
         iconClass: icon-rh-openjdk
@@ -63,15 +57,11 @@ objects:
         sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
         supports: java:8
         tags: builder,java,openjdk
-        version: "1.2"
+        version: '1.2'
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/redhat-openjdk18-openshift:1.2
-      generation: 2
-      importPolicy: {}
-      name: "1.2"
-      referencePolicy:
-        type: Source
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.2
+      name: '1.2'
 - apiVersion: v1
   kind: ImageStream
   metadata:

--- a/basic-spring-boot/applier/templates/build.yml
+++ b/basic-spring-boot/applier/templates/build.yml
@@ -15,7 +15,6 @@ objects:
   metadata:
     annotations:
       openshift.io/display-name: Red Hat OpenJDK 8
-      openshift.io/image.dockerRepositoryCheck: 2018-04-06T20:39:19Z
       openshift.io/provider-display-name: Red Hat, Inc.
       version: 1.4.8
     name: redhat-openjdk18-openshift


### PR DESCRIPTION
Removed leading slash from APP_NAME so build would succeed.  Updated application source URL to use master from https://github.com/redhat-cop/spring-rest instead of https://github.com/etsauer/spring-rest repo/branch.  Also added openjdk imagestream to build template, so this succeeds when imagestream is not initially present (e.g. minishift without templates/imagestreams).

```
git clone https://github.com/redhat-cop/container-pipelines.git
cd container-pipelines/basic-spring-boot/
ansible-playbook -i ./applier/inventory/ /path/to/openshift-applier/playbooks/openshift-cluster-seed.yml
```
Verify the basic-spring-boot pipelines and applications are successful.

cc: @redhat-cop/containers-approvers 