### PR TITLE
Fixed Basic Spring Boot applier inventory broken for non-privileged users

### DIFF
--- a/basic-spring-boot/applier/templates/build.yml
+++ b/basic-spring-boot/applier/templates/build.yml
@@ -20,7 +20,7 @@ objects:
       openshift.io/provider-display-name: Red Hat, Inc.
       version: 1.4.8
     name: redhat-openjdk18-openshift
-    namespace: ${IMAGE_STREAM_NAMESPACE}
+    namespace: ${NAMESPACE}
   spec:
     tags:
     - annotations:


### PR DESCRIPTION
#### What does this PR do?
Updated the openjdk IS metadata `namespace: ${IMAGE_STREAM_NAMESPACE}` to `namespace: ${NAMESPACE}` in order to make this work for non-privileged users.  The openjdk18 imagestream is now created in the `basic-spring-boot-build` project.

#### How should this be tested?
build and verify the Basic Spring Boot application is created and deployed to all 3 projects.

#### Is there a relevant Issue open for this?
Yes #27 

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers @etsauer 
