### PR TITLE
Removed OpenJDK from build template

### DIFF
--- a/basic-spring-boot/README.md
+++ b/basic-spring-boot/README.md
@@ -58,7 +58,8 @@ This pipeline defaults to use our [Spring Boot Demo App](https://github.com/redh
 ## Bill of Materials
 
 * One or Two OpenShift Container Platform Clusters
-  * OpenShift 3.5+ is required.
+  * OpenShift 3.5+ is required
+  * [Red Hat OpenJDK 1.8](https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift) image is required
 * Access to GitHub
 
 ## Manual Deployment Instructions

--- a/basic-spring-boot/applier/templates/build.yml
+++ b/basic-spring-boot/applier/templates/build.yml
@@ -12,58 +12,6 @@ metadata:
 objects:
 - apiVersion: v1
   kind: ImageStream
-  labels:
-    xpaas: 1.4.8
-  metadata:
-    annotations:
-      openshift.io/display-name: Red Hat OpenJDK 8
-      openshift.io/provider-display-name: Red Hat, Inc.
-      version: 1.4.8
-    name: redhat-openjdk18-openshift
-    namespace: ${NAMESPACE}
-  spec:
-    tags:
-    - annotations:
-        description: Build and run Java applications using Maven and OpenJDK 8.
-        iconClass: icon-rh-openjdk
-        openshift.io/display-name: Red Hat OpenJDK 8
-        sampleContextDir: undertow-servlet
-        sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
-        supports: java:8
-        tags: builder,java,openjdk,hidden
-        version: '1.0'
-      from:
-        kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.0
-      name: '1.0'
-    - annotations:
-        description: Build and run Java applications using Maven and OpenJDK 8.
-        iconClass: icon-rh-openjdk
-        openshift.io/display-name: Red Hat OpenJDK 8
-        sampleContextDir: undertow-servlet
-        sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
-        supports: java:8
-        tags: builder,java,openjdk
-        version: '1.1'
-      from:
-        kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.1
-      name: '1.1'
-    - annotations:
-        description: Build and run Java applications using Maven and OpenJDK 8.
-        iconClass: icon-rh-openjdk
-        openshift.io/display-name: Red Hat OpenJDK 8
-        sampleContextDir: undertow-servlet
-        sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
-        supports: java:8
-        tags: builder,java,openjdk
-        version: '1.2'
-      from:
-        kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.2
-      name: '1.2'
-- apiVersion: v1
-  kind: ImageStream
   metadata:
     labels:
       application: ${APPLICATION_NAME}


### PR DESCRIPTION
#### What does this PR do?
This PR removes the Red Hat OpenJDK imagestream from the build.yaml and moves this requirement to the bill of materials.  If you run CDK w/ xpaas images installed this will just work. If using minishift or w/o xpaas images installed, the OpenJDK image will need to be added to OpenShift.

#### How should this be tested?
Verify that the OpenJDK imagestream has been removed from the build.yaml template.  Then deploy the basic-spring-boot pipeline and application and verify all is successful.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers @etsauer 
