### PR TITLE
Point README to build project for pipeline, fixes #38

### DIFF
--- a/basic-spring-boot/README.md
+++ b/basic-spring-boot/README.md
@@ -45,7 +45,7 @@ The second template, `applier/templates/deployment.yml` is the "Deploy" template
 * A Service definition
 * A Route
 
-The idea behind the split between the templates is that I can deploy the build template only once (to my dev project) and that the pipeline will promote my image through all of the various stages of my application's lifecycle. The deployment template gets deployed once to each of the stages of the application lifecycle (once per OpenShift project).
+The idea behind the split between the templates is that I can deploy the build template only once (to my build project) and that the pipeline will promote my image through all of the various stages of my application's lifecycle. The deployment template gets deployed once to each of the stages of the application lifecycle (once per OpenShift project).
 
 ### Pipeline Script
 
@@ -137,14 +137,14 @@ A _build template_ is provided at `applier/templates/build.yml` that defines all
 * A `BuildConfig` that defines a `JenkinsPipelineStrategy` build, which will be used to define out pipeline.
 * A `BuildConfig` that defines a `Source` build with `Binary` input. This will build our image.
 
-Deploy the pipeline template in dev only.
+Deploy the pipeline template in build only.
 ```
 $ oc process -f applier/templates/build.yml --param-file applier/params/build-dev | oc apply -f-
 buildconfig "spring-rest-pipeline" created
 buildconfig "spring-rest" created
 ```
 
-At this point you should be able to go to the Web Console and follow the pipeline by clicking in your `basic-spring-boot-dev` project, and going to *Builds* -> *Pipelines*. At several points you will be prompted for input on the pipeline. You can interact with it by clicking on the _input required_ link, which takes you to Jenkins, where you can click the *Proceed* button. By the time you get through the end of the pipeline you should be able to visit the Route for your app deployed to the `myapp-prod` project to confirm that your image has been promoted through all stages.
+At this point you should be able to go to the Web Console and follow the pipeline by clicking in your `basic-spring-boot-build` project, and going to *Builds* -> *Pipelines*. At several points you will be prompted for input on the pipeline. You can interact with it by clicking on the _input required_ link, which takes you to Jenkins, where you can click the *Proceed* button. By the time you get through the end of the pipeline you should be able to visit the Route for your app deployed to the `myapp-prod` project to confirm that your image has been promoted through all stages.
 
 ## Cleanup
 

--- a/basic-tomcat/README.md
+++ b/basic-tomcat/README.md
@@ -46,7 +46,7 @@ The second template, `files/deployment/template.yml` is the "Deploy" template. I
 * A Service definition
 * A Route
 
-The idea behind the split between the templates is that I can deploy the build template only once (to my dev project) and that the pipeline will promote my image through all of the various stages of my application's lifecycle. The deployment template gets deployed once to each of the stages of the application lifecycle (once per OpenShift project).
+The idea behind the split between the templates is that I can deploy the build template only once (to my build project) and that the pipeline will promote my image through all of the various stages of my application's lifecycle. The deployment template gets deployed once to each of the stages of the application lifecycle (once per OpenShift project).
 
 ### Pipeline Script
 
@@ -100,7 +100,7 @@ A _build template_ is provided at `files/builds/template.yml` that defines all t
 * A `BuildConfig` that defines a `JenkinsPipelineStrategy` build, which will be used to define out pipeline.
 * A `BuildConfig` that defines a `Source` build with `Binary` input. This will build our image.
 
-At this point you should be able to go to the Web Console and follow the pipeline by clicking in your `myapp-dev` project, and going to *Builds* -> *Pipelines*. At several points you will be prompted for input on the pipeline. You can interact with it by clicking on the _input required_ link, which takes you to Jenkins, where you can click the *Proceed* button. By the time you get through the end of the pipeline you should be able to visit the Route for your app deployed to the `myapp-prod` project to confirm that your image has been promoted through all stages.
+At this point you should be able to go to the Web Console and follow the pipeline by clicking in your `basic-tomcat-build` project, and going to *Builds* -> *Pipelines*. At several points you will be prompted for input on the pipeline. You can interact with it by clicking on the _input required_ link, which takes you to Jenkins, where you can click the *Proceed* button. By the time you get through the end of the pipeline you should be able to visit the Route for your app deployed to the `myapp-prod` project to confirm that your image has been promoted through all stages.
 
 ## Cleanup
 

--- a/blue-green-spring/README.md
+++ b/blue-green-spring/README.md
@@ -64,7 +64,7 @@ The third template, `files/deployment/template-bg.yml` is the "Deploy" template 
 * Two Service definition's
 * A Route
 
-The idea behind the split between the templates is that I can deploy the build template only once (to my dev project) and that the pipeline will promote my image through all of the various stages of my application's lifecycle. The deployment template gets deployed once to each of the stages of the application lifecycle (once per OpenShift project).
+The idea behind the split between the templates is that I can deploy the build template only once (to my build project) and that the pipeline will promote my image through all of the various stages of my application's lifecycle. The deployment template gets deployed once to each of the stages of the application lifecycle (once per OpenShift project).
 
 ### Pipeline Script
 
@@ -128,7 +128,7 @@ A _build template_ is provided at `builds/template.yml` that defines all the res
 * A `BuildConfig` that defines a `JenkinsPipelineStrategy` build, which will be used to define out pipeline.
 * A `BuildConfig` that defines a `Source` build with `Binary` input. This will build our image.
 
-At this point you should be able to go to the Web Console and follow the pipeline by clicking in your `myapp-dev` project, and going to *Builds* -> *Pipelines*. There is a prompt for input on the pipeline before the production route is switched to the new deployment. You can interact with it by clicking on the _input required_ link, which takes you to Jenkins, where you can click the *Proceed* button. By the time you get through the end of the pipeline you should be able to visit the Route for your app deployed to the `myapp-prod` project to confirm that your image has been promoted through all stages.
+At this point you should be able to go to the Web Console and follow the pipeline by clicking in your `spring-boot-web-build` project, and going to *Builds* -> *Pipelines*. There is a prompt for input on the pipeline before the production route is switched to the new deployment. You can interact with it by clicking on the _input required_ link, which takes you to Jenkins, where you can click the *Proceed* button. By the time you get through the end of the pipeline you should be able to visit the Route for your app deployed to the `myapp-prod` project to confirm that your image has been promoted through all stages.
 
 ## Cleanup
 


### PR DESCRIPTION
#### What does this PR do?
Update READMEs to direct to the `-build` project to view Jenkins pipelines

#### How should this be tested?
No testing required, reading and typo checking should be enough.

#### Is there a relevant Issue open for this?
resolves #38 

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
