### PR TITLE
hide Maven download status in logs

### DIFF
--- a/basic-spring-boot/Jenkinsfile
+++ b/basic-spring-boot/Jenkinsfile
@@ -45,14 +45,14 @@ pipeline {
     // Run Maven build, skipping tests
     stage('Build'){
       steps {
-        sh "mvn clean install -DskipTests=true -f ${POM_FILE}"
+        sh "mvn -B clean install -DskipTests=true -f ${POM_FILE}"
       }
     }
 
     // Run Maven unit tests
     stage('Unit Test'){
       steps {
-        sh "mvn test -f ${POM_FILE}"
+        sh "mvn -B test -f ${POM_FILE}"
       }
     }
 

--- a/basic-tomcat/Jenkinsfile
+++ b/basic-tomcat/Jenkinsfile
@@ -31,13 +31,13 @@ pipeline {
 
     stage('Build') {
       steps {
-        sh "mvn clean install -DskipTests=true -f ${POM_FILE}"
+        sh "mvn -B clean install -DskipTests=true -f ${POM_FILE}"
       }
     }
 
     stage('Unit Test') {
       steps {
-        sh "mvn test -f ${POM_FILE}"
+        sh "mvn -B test -f ${POM_FILE}"
       }
     }
 

--- a/blue-green-spring/Jenkinsfile
+++ b/blue-green-spring/Jenkinsfile
@@ -48,13 +48,13 @@ pipeline {
     
     stage('Build') {
       steps {
-        sh "mvn clean install -DskipTests=true -f ${pom_file}"
+        sh "mvn -B clean install -DskipTests=true -f ${pom_file}"
       }
     }
 
     stage('Unit Test') {
       steps {
-        sh "mvn test -f ${pom_file}"
+        sh "mvn -B test -f ${pom_file}"
       }
     }
 

--- a/multi-cluster-spring-boot/image-mirror-example/Jenkinsfile
+++ b/multi-cluster-spring-boot/image-mirror-example/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     stage('Code Build') {
       steps {
         git url: "${SOURCE_CODE_URL}"
-        sh "mvn clean install -q"
+        sh "mvn -B clean install -q"
       }
     }
 

--- a/multi-cluster-spring-boot/skopeo-example/Jenkinsfile
+++ b/multi-cluster-spring-boot/skopeo-example/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     stage('Code Build') {
       steps {
         git url: "${SOURCE_CODE_URL}"
-        sh "mvn clean install -q"
+        sh "mvn -B clean install -q"
       }
     }
 


### PR DESCRIPTION
#### What does this PR do?
Maven artifact download status lines tend to dominate Jenkins pipeline logs and inflate the total size by up to 10x. This PR adds a flag to Maven commands to suppress the download status logs so there is only two lines generated for each Maven artifact.

So
```
[INFO] Downloading: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-parent/1.5.8.RELEASE/spring-boot-parent-1.5.8.RELEASE.pom
[INFO] Downloaded: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-parent/1.5.8.RELEASE/spring-boot-parent-1.5.8.RELEASE.pom (28 kB at 278 kB/s)
```
instead of
```
Downloading: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-parent/1.5.8.RELEASE/spring-boot-parent-1.5.8.RELEASE.pom
Progress (1): 2.2/28 kB
Progress (1): 5.0/28 kB
Progress (1): 7.8/28 kB
Progress (1): 11/28 kB 
Progress (1): 13/28 kB
Progress (1): 16/28 kB
Progress (1): 19/28 kB
Progress (1): 21/28 kB
Progress (1): 24/28 kB
Progress (1): 27/28 kB
Progress (1): 28 kB 
```

#### How should this be tested?
Choose a pipeline that leverages Maven and add the following build params:
```
SOURCE_REPOSITORY_URL=https://github.com/davgordo/container-pipelines.git
SOURCE_REPOSITORY_REF=maven-logs
```
then deploy the pipeline as per README

#### Is there a relevant Issue open for this?
No issue logged

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
