### PR TITLE
Remove OWASP checks from basic-spring-boot build step

### DIFF
--- a/basic-spring-boot/Jenkinsfile
+++ b/basic-spring-boot/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
     // Run Maven build, skipping tests
     stage('Build'){
       steps {
-        sh "mvn -B clean install -DskipTests=true -f ${POM_FILE}"
+        sh "mvn -B clean package -DskipTests=true -f ${POM_FILE}"
       }
     }
 


### PR DESCRIPTION
#### What does this PR do?
Avoids the verify maven goal which skips the OWASP checks.
OWASP is not featured in this example, and the checks are failing intermittently, including for [spring-rest/#32](https://github.com/redhat-cop/spring-rest/issues/32)

#### How should this be tested?
Deploy the pipeline and verify the build stage succeeds.

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
