### PR TITLE
OpenShift Binary Build changed a parameter name

### DIFF
--- a/basic-spring-boot/Jenkinsfile
+++ b/basic-spring-boot/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
         // Giving all the artifacts to OpenShift Binary Build
         // This places your artifacts into right location inside your S2I image
         // if the S2I image supports it.
-        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, artifactsDirectoryName: "oc-build")
+        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, buildFromPath: "oc-build")
       }
     }
 


### PR DESCRIPTION
In order to make this work the change is need due to the update in the library https://github.com/redhat-cop/pipeline-library/commit/933b788e2f21dca57c873e3e8a794cc6e0e46126#diff-9c4d8b18cdd602829bcf0b7919b2e908

The parameter "artifactsDirectoryName" was changed to  "buildFromPath"
