### PR TITLE
Fix multi cluster pipeline to support applier v2.1.1

### DIFF
--- a/multi-cluster-spring-boot/image-mirror-example/.applier/inventory-pre-dev/group_vars/seed-hosts.yml
+++ b/multi-cluster-spring-boot/image-mirror-example/.applier/inventory-pre-dev/group_vars/seed-hosts.yml
@@ -3,7 +3,7 @@ openshift_cluster_content:
   content:
   - name: "create environments"
     file: "{{ inventory_dir }}/../projects/projects.yml"
-    file_action: create
+    action: create
 - object: deployments
   content:
   - name: "create image mirror service account"

--- a/multi-cluster-spring-boot/image-mirror-example/.applier/inventory-prod/group_vars/seed-hosts.yml
+++ b/multi-cluster-spring-boot/image-mirror-example/.applier/inventory-prod/group_vars/seed-hosts.yml
@@ -3,7 +3,7 @@ openshift_cluster_content:
   content:
   - name: "create environments"
     file: "{{ inventory_dir }}/../projects/projects-prod.yml"
-    file_action: create
+    action: create
   - name: "create prod cluster credential"
     template: "{{ inventory_dir }}/../templates/image-mirror-sa.yml"
     params: "{{ inventory_dir }}/../params/registry-sa-prod-cluster"

--- a/multi-cluster-spring-boot/requirements.yml
+++ b/multi-cluster-spring-boot/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.10
+  version: v2.1.1

--- a/multi-cluster-spring-boot/requirements.yml
+++ b/multi-cluster-spring-boot/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.6
+  version: v2.0.10

--- a/multi-cluster-spring-boot/skopeo-example/.applier/inventory-dev/group_vars/seed-hosts.yml
+++ b/multi-cluster-spring-boot/skopeo-example/.applier/inventory-dev/group_vars/seed-hosts.yml
@@ -3,7 +3,7 @@ openshift_cluster_content:
   content:
   - name: "create environments"
     file: "{{ inventory_dir }}/../projects/projects.yml"
-    file_action: create
+    action: create
 - object: deployments
   content:
   - name: "deploy jenkins"

--- a/multi-cluster-spring-boot/skopeo-example/.applier/inventory-prod/group_vars/seed-hosts.yml
+++ b/multi-cluster-spring-boot/skopeo-example/.applier/inventory-prod/group_vars/seed-hosts.yml
@@ -3,7 +3,7 @@ openshift_cluster_content:
   content:
   - name: "create environments"
     file: "{{ inventory_dir }}/../projects/projects-prod.yml"
-    file_action: create
+    action: create
   - name: "create promoter account"
     file: "{{ inventory_dir }}/../projects/promoter-sa.yml"
 - object: deployments


### PR DESCRIPTION
#### What does this PR do?
This is to update the multi-cluster-spring-boot to be compatible with applier v2.1.1

#### How should this be tested?
Use Read Me to do the installation using the new pushed code

#### Is there a relevant Issue open for this?
This was related to the PR Fix multi cluster pipeline to support applier v2.0.10, deleted by mistake

#### Who would you like to review this?
@pabrahamsson
cc: @redhat-cop/containers-approvers
