### PR TITLE
Fix binaryBuild call to match pipeline libary changes

### DIFF
--- a/basic-nginx/Jenkinsfile
+++ b/basic-nginx/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 
     stage('Image Build') {
       steps {
-        binaryBuild(projectName: "${BUILD}", buildConfigName: "${APP_NAME}", artifactsDirectoryName: "${ARTIFACT_DIRECTORY}")
+        binaryBuild(projectName: "${BUILD}", buildConfigName: "${APP_NAME}", buildFromPath: "${ARTIFACT_DIRECTORY}")
       }
     }
 

--- a/basic-spring-boot/Jenkinsfile.hygieia
+++ b/basic-spring-boot/Jenkinsfile.hygieia
@@ -90,7 +90,7 @@ pipeline {
         // Giving all the artifacts to OpenShift Binary Build
         // This places your artifacts into right location inside your S2I image
         // if the S2I image supports it.
-        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, artifactsDirectoryName: "oc-build")
+        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, buildFromPath: "oc-build")
       }
     }
 

--- a/basic-tomcat/Jenkinsfile
+++ b/basic-tomcat/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             cp -rfv ./${TARGET}/*.\$t oc-build/deployments/ 2> /dev/null || echo "No \$t files"
           done
         """
-        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, artifactsDirectoryName: "oc-build")
+        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, buildFromPath: "oc-build")
       }
     }
 

--- a/blue-green-spring/Jenkinsfile
+++ b/blue-green-spring/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
             cp -rfv ./${TARGET}/*.\$t oc-build/deployments/ 2> /dev/null || echo "No \$t files"
           done
         """
-        binaryBuild(projectName: BUILD, buildConfigName: APP_NAME, artifactsDirectoryName: "oc-build")
+        binaryBuild(projectName: BUILD, buildConfigName: APP_NAME, buildFromPath: "oc-build")
       }
     }
 

--- a/secure-spring-boot/Jenkinsfile
+++ b/secure-spring-boot/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
     // Build Container Image using the artifacts produced in previous stages
     stage('Build Container Image'){
       steps {
-        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, artifactsDirectoryName: "${env.BUILD_OUTPUT_DIR}");
+        binaryBuild(projectName: env.BUILD, buildConfigName: env.APP_NAME, buildFromPath: "${env.BUILD_OUTPUT_DIR}")
       }
     }
 


### PR DESCRIPTION
[1] https://github.com/redhat-cop/pipeline-library/commit/933b788e2f21dca57c873e3e8a794cc6e0e46126

#### What does this PR do?
Updates the `binaryBuild` call in serveral project's `Jenkinsfile`. The upstream `pipeline-library` project changed the method signature and broke these builds. See [1]

#### How should this be tested?
Run any of the pipelines that use a binary build strategy. 

Prior to this fix you'll see a failure.
```
groovy.lang.MissingPropertyException: No such property: artifactsDirectoryName for class: BinaryBuildInput
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$NoParamSite.callConstructor(ConstructorSite.java:127)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:60)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:235)
	at org.kohsuke.groovy.sandbox.impl.Checker$3.call(Checker.java:201)
	at org.kohsuke.groovy.sandbox.GroovyInterceptor.onNewInstance(GroovyInterceptor.java:42)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onNewInstance(SandboxInterceptor.java:168)
	at org.kohsuke.groovy.sandbox.impl.Checker$3.call(Checker.java:198)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedConstructor(Checker.java:203)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.constructorCall(SandboxInvoker.java:21)
	at binaryBuild.call(/var/lib/jenkins/jobs/basic-tomcat-build/jobs/basic-tomcat-build-basic-tomcat-pipeline/builds/1/libs/pipeline-library/vars/binaryBuild.groovy:13)
	at WorkflowScript.run(WorkflowScript:53)
```

With the fix the pipeline run will succeed.
```
Start & Follow Build
[Pipeline] readFile
[Pipeline] _OcAction
[Pipeline] readFile
[Pipeline] _OcAction
[logs:build/basic-tomcat-1] Receiving source from STDIN as archive ...
[logs:build/basic-tomcat-1] Caching blobs under "/var/cache/blobs".
[logs:build/basic-tomcat-1] Getting image source signatures
[logs:build/basic-tomcat-1] Copying blob sha256:78f9ea175a0a36eeccd5399d82c03146149c4d6ad6afa134cb314c7d3be7dab9
[logs:build/basic-tomcat-1] Copying blob sha256:26e5ed6899dbf4b1e93e0898255e8aaf43465cecd3a24910f26edb5d43dafa3c
[logs:build/basic-tomcat-1] Copying blob sha256:c0b0e6c1b640832b6453d4b407cc9387d9076f8c843808e454c675ec24cc2e0e
[logs:build/basic-tomcat-1] Copying blob sha256:f1aa4becab33cce40f431856e4a9d678adc9d7f9fbd50a59c77197f25eed968a
[logs:build/basic-tomcat-1] Copying blob sha256:66dbe984a319ca6d40dc10c2c561821128a0bd8967e0cbd8cc2a302736041ffb
[logs:build/basic-tomcat-1] Copying blob sha256:39fe8b1d3a9cb13a361204c23cf4e342d53184b4440492fa724f4aeb4eb1d64f
[logs:build/basic-tomcat-1] Writing manifest to image destination
[logs:build/basic-tomcat-1] Storing signatures
[logs:build/basic-tomcat-1] Generating dockerfile with builder image image-registry.openshift-image-registry.svc:5000/openshift/jboss-webserver31-tomcat8-openshift@sha256:6b78482f17da060b55ba6c92064a9235b9b38fff0eaaccc6923e23e597d66756
```

#### Is there a relevant Issue open for this?


#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
