### PR TITLE
Added stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,38 @@
+## Configuration for probot-stale - https://github.com/probot/stale
+#
+## Number of days of inactivity before an Issue or Pull Request becomes stale
+#daysUntilStale: 60
+## Number of days of inactivity before a stale Issue or Pull Request is closed.
+## Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+#daysUntilClose: 7
+## Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+#exemptLabels:
+#  - pinned
+#  - security
+#  - "[Status] Maybe Later"
+## Label to use when marking as stale
+#staleLabel: wontfix
+## Comment to post when marking as stale. Set to `false` to disable
+#markComment: >
+#  This issue has been automatically marked as stale because it has not had
+#  recent activity. It will be closed if no further activity occurs. Thank you
+#  for your contributions.
+## Comment to post when removing the stale label. Set to `false` to disable
+#unmarkComment: false
+## Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+#closeComment: false
+## Limit the number of actions per hour, from 1-30. Default is 30
+#limitPerRun: 30
+## Limit to only `issues` or `pulls`
+## only: issues
+##
+## Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+## pulls:
+##   daysUntilStale: 30
+##   markComment: >
+##     This pull request has been automatically marked as stale because it has not had
+##     recent activity. It will be closed if no further activity occurs. Thank you
+##     for your contributions.
+## issues:
+##   exemptLabels:
+##     - confirmed


### PR DESCRIPTION
#### What does this PR do?
@etsauer enabled stalebot for the org. for it to run on the repo, we need this file. file is copied from:
- https://raw.githubusercontent.com/redhat-cop/uncontained.io/master/.github/stale.yml

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
