### PR TITLE
Fix task input syntax

### DIFF
--- a/basic-spring-boot-tekton/.openshift/templates/build.yml
+++ b/basic-spring-boot-tekton/.openshift/templates/build.yml
@@ -121,8 +121,8 @@ objects:
         command: ["/usr/local/bin/oc"]
         args:
           - tag
-          - "${inputs.params.fromNamespace}/${inputs.params.imageStream}:${inputs.params.tag}"
-          - "${inputs.params.toNamespace}/${inputs.params.imageStream}:${inputs.params.tag}"
+          - "$(inputs.params.fromNamespace)/$(inputs.params.imageStream):$(inputs.params.tag)"
+          - "$(inputs.params.toNamespace)/$(inputs.params.imageStream):$(inputs.params.tag)"
       # not sure what to do here
       - name: verify-deployment
         image: quay.io/openshift-pipeline/openshift-cli:latest


### PR DESCRIPTION
#### What does this PR do?
Fix the syntax issue during the deploy task.
At the moment, the variables are not interpreted correctly as the task input syntax is incorrect.

See [tektoncd](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md#inputs) for the correct syntax reference. We should use parentheses instead of curly braces.

#### How should this be tested?
Follow the manual instructions to setup the projects, the tasks, the pipelines...
Start the pipeline and wait for the first task to be completed (build). the deploy task will fail.
The step "oc tag source destination" will fail as the source reference is invalid.

#### Is there a relevant Issue open for this?
No open issue. I just read the readme and tried it

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
cc: @raffaelespazzoli 
cc: @sabre1041 