### PR TITLE
Removed id from route from  basic-spring-boot

### DIFF
--- a/basic-spring-boot/.openshift/templates/deployment.yml
+++ b/basic-spring-boot/.openshift/templates/deployment.yml
@@ -26,7 +26,6 @@ objects:
     selector:
       deploymentConfig: ${APPLICATION_NAME}
 - apiVersion: v1
-  id: ${APPLICATION_NAME}-http
   kind: Route
   metadata:
     annotations:


### PR DESCRIPTION
#### What does this PR do?
Route object contains a random "id" at top-level. This isn't valid against the route spec, unless I've missed something.

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
