### PR TITLE
Align app labels with kubernetes recommendations

### DIFF
--- a/basic-spring-boot/.applier/group_vars/seed-hosts.yml
+++ b/basic-spring-boot/.applier/group_vars/seed-hosts.yml
@@ -46,7 +46,7 @@ openshift_cluster_content:
       READINESS_PATH: "{{ sb_application_readiness_path }}"
     tags:
       - deployment
-  - name: "deply stage environment"
+  - name: "deploy stage environment"
     template: "{{ inventory_dir }}/../.openshift/templates/deployment.yml"
     params_from_vars:
       APPLICATION_NAME: "{{ sb_application_name }}"
@@ -68,3 +68,7 @@ openshift_cluster_content:
       READINESS_PATH: "{{ sb_application_readiness_path }}"
     tags:
       - deployment
+  - name: "deploy jenkins to build environment"
+    template: "openshift//jenkins-ephemeral"
+    tags:
+      - build

--- a/basic-spring-boot/.openshift/projects/projects.yml
+++ b/basic-spring-boot/.openshift/projects/projects.yml
@@ -23,5 +23,7 @@ items:
   apiVersion: v1
   metadata:
     name: basic-spring-boot-prod
+    labels:
+      environment: production
     creationTimestam: null
   displayName: Spring Rest App - Prod

--- a/basic-spring-boot/.openshift/templates/build.yml
+++ b/basic-spring-boot/.openshift/templates/build.yml
@@ -14,14 +14,22 @@ objects:
   kind: ImageStream
   metadata:
     labels:
-      application: ${APPLICATION_NAME}
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}-build
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
     name: ${APPLICATION_NAME}
     namespace: ${NAMESPACE}
 - kind: "BuildConfig"
   apiVersion: "v1"
   metadata:
     labels:
-      application: ${APPLICATION_NAME}
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}-build
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
     name: "${APPLICATION_NAME}-pipeline"
     namespace: "${NAMESPACE}"
   spec:
@@ -49,7 +57,11 @@ objects:
   kind: BuildConfig
   metadata:
     labels:
-      application: ${APPLICATION_NAME}
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}-build
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
     name: ${APPLICATION_NAME}
     namespace: "${NAMESPACE}"
   spec:

--- a/basic-spring-boot/.openshift/templates/deployment.yml
+++ b/basic-spring-boot/.openshift/templates/deployment.yml
@@ -16,7 +16,11 @@ objects:
     annotations:
       description: The web server's http port.
     labels:
-      app: ${APPLICATION_NAME}
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
     name: ${APPLICATION_NAME}
     namespace: ${NAMESPACE}
   spec:
@@ -32,7 +36,11 @@ objects:
     annotations:
       description: Route for application's http service.
     labels:
-      app: ${APPLICATION_NAME}
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
     name: ${APPLICATION_NAME}
     namespace: ${NAMESPACE}
   spec:
@@ -43,14 +51,22 @@ objects:
   kind: ImageStream
   metadata:
     labels:
-      app: ${APPLICATION_NAME}
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
     name: ${APPLICATION_NAME}
     namespace: ${NAMESPACE}
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:
-      app: ${APPLICATION_NAME}
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
     name: ${APPLICATION_NAME}
     namespace: ${NAMESPACE}
   spec:
@@ -62,7 +78,11 @@ objects:
     template:
       metadata:
         labels:
-          app: ${APPLICATION_NAME}
+          app.kubernetes.io/name: ${APPLICATION_NAME}
+          app.kubernetes.io/instance: ${APPLICATION_NAME}
+          app.kubernetes.io/component: api
+          app.kubernetes.io/part-of: ${APPLICATION_NAME}
+          app.kubernetes.io/managed-by: applier
           deploymentConfig: ${APPLICATION_NAME}
         name: ${APPLICATION_NAME}
       spec:
@@ -106,6 +126,11 @@ objects:
   metadata:
     creationTimestamp: null
     labels:
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: ${APPLICATION_NAME}
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: ${APPLICATION_NAME}
+      app.kubernetes.io/managed-by: applier
       template: basic-tomcat-template
     name: jenkins_edit
     namespace: ${NAMESPACE}


### PR DESCRIPTION
#### What does this PR do?
Align with kubernetes recommended app labels

#### How should this be tested?
Deploy basic-spring-boot pipeline, and check to make sure all resulting resources have the following labels on them:

```
      app.kubernetes.io/name:
      app.kubernetes.io/instance:
      app.kubernetes.io/component:
      app.kubernetes.io/part-of:
      app.kubernetes.io/managed-by:
```

Before we merge, we might want to have a discussion about how we assign values to these.

#### Is there a relevant Issue open for this?
related to #119 

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
