### PR TITLE
Add build namespace to jenkins deployment

### DIFF
--- a/basic-spring-boot/.applier/group_vars/seed-hosts.yml
+++ b/basic-spring-boot/.applier/group_vars/seed-hosts.yml
@@ -70,5 +70,6 @@ openshift_cluster_content:
       - deployment
   - name: "deploy jenkins to build environment"
     template: "openshift//jenkins-ephemeral"
+    namespace: "{{ sb_build_namespace }}"
     tags:
       - build


### PR DESCRIPTION
#### What does this PR do?
Specify the missing build namespace for Jenkins as described in #133.

#### How should this be tested?
```
$ oc new-project my-newproject
$ oc delete project my-newproject
$ ansible-playbook -i ./.applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
```

#### Is there a relevant Issue open for this?
fixes #133 

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
