### PR TITLE
minor typo fix in springboot readme

### DIFF
--- a/basic-spring-boot/README.md
+++ b/basic-spring-boot/README.md
@@ -111,13 +111,13 @@ This template should be instantiated once in each of the namespaces that our app
 
 Deploy the deployment template to all three projects.
 ```
-$ oc process -f .openshift/templates/deployment.yml -p=APPLICATION_NAME=basic-spring-boot
- -p NAMESPACE=basic-spring-boot-dev -p=SA_NAMESPACE=basic-spring-boot-build -p=READINESS_PATH="/health" -p=READINESS_RESPONSE="status.:.UP" -p | oc apply -f-
+$ oc process -f .openshift/templates/deployment.yml -p APPLICATION_NAME=basic-spring-boot  -p NAMESPACE=basic-spring-boot-dev -p SA_NAMESPACE=basic-spring-boot-build -p READINESS_PATH="/health" -p READINESS_RESPONSE="status.:.UP" | oc apply -f-
 service "spring-rest" created
 route "spring-rest" created
 imagestream "spring-rest" created
 deploymentconfig "spring-rest" created
 rolebinding "jenkins_edit" configured
+
 $ oc process -f .openshift/templates/deployment.yml -p=APPLICATION_NAME=basic-spring-boot
  -p NAMESPACE=basic-spring-boot-stage -p=SA_NAMESPACE=basic-spring-boot-build -p=READINESS_PATH="/health" -p=READINESS_RESPONSE="status.:.UP" -p | oc apply -f-
 service "spring-rest" created
@@ -125,8 +125,8 @@ route "spring-rest" created
 imagestream "spring-rest" created
 deploymentconfig "spring-rest" created
 rolebinding "jenkins_edit" created
-$ oc process -f .openshift/templates/deployment.yml -p=APPLICATION_NAME=basic-spring-boot
- -p NAMESPACE=basic-spring-boot-prod -p=SA_NAMESPACE=basic-spring-boot-build -p=READINESS_PATH="/health" -p=READINESS_RESPONSE="status.:.UP" -p | oc apply -f-
+
+$ oc process -f .openshift/templates/deployment.yml -p=APPLICATION_NAME=basic-spring-boot  -p NAMESPACE=basic-spring-boot-prod -p SA_NAMESPACE=basic-spring-boot-build -p READINESS_PATH="/health" -p READINESS_RESPONSE="status.:.UP" | oc apply -f-
 service "spring-rest" created
 route "spring-rest" created
 imagestream "spring-rest" created
@@ -141,8 +141,7 @@ A _build template_ is provided at `applier/templates/build.yml` that defines all
 
 Deploy the pipeline template in build only.
 ```
-$ oc process -f applier/templates/build.yml -p=APPLICATION_NAME=basic-spring-boot
- -p NAMESPACE=basic-spring-boot-dev -p=SOURCE_REPOSITORY_URL="https://github.com/redhat-cop/container-pipelines.git" -p=APPLICATION_SOURCE_REPO="https://github.com/redhat-cop/spring-rest.git" | oc apply -f-
+$ oc process -f applier/templates/build.yml -p=APPLICATION_NAME=basic-spring-boot -p NAMESPACE=basic-spring-boot-build -p=SOURCE_REPOSITORY_URL="https://github.com/redhat-cop/container-pipelines.git" -p APPLICATION_SOURCE_REPO="https://github.com/redhat-cop/spring-rest.git" | oc apply -f-
 buildconfig "spring-rest-pipeline" created
 buildconfig "spring-rest" created
 ```


### PR DESCRIPTION
#### What does this PR do?
Minor typo fix in the documentation of basic-spring-boot README

#### How should this be tested?
Failing because the -p=<PARAMETER> and because the final -p:
```
oc process -f .openshift/templates/deployment.yml -p=APPLICATION_NAME=basic-spring-boot  -p NAMESPACE=basic-spring-boot-dev -p=SA_NAMESPACE=basic-spring-boot-build  -p=READINESS_PATH="/health" -p=READINESS_RESPONSE="status.:.UP" -p | oc apply -f-
Error: flag needs an argument: 'p' in -p
See 'oc process --help' for usage.
```

Solved with the proper params spaces and deleting the non-used -p 
```
 oc process -f .openshift/templates/deployment.yml -p=APPLICATION_NAME=basic-spring-boot  -p NAMESPACE=basic-spring-boot-dev -p SA_NAMESPACE=basic-spring-boot-build  -p READINESS_PATH="/health" -p READINESS_RESPONSE="status.:.UP" | oc apply -f-
service/basic-spring-boot created
route.route.openshift.io/basic-spring-boot created
imagestream.image.openshift.io/basic-spring-boot created
deploymentconfig.apps.openshift.io/basic-spring-boot created
rolebinding.rbac.authorization.k8s.io/jenkins_edit created
```

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
