### PR TITLE
Add changes for Task and Pipeline using v1beta1 version instead of v1alpha1

### DIFF
--- a/basic-spring-boot-tekton/.openshift/templates/build.yml
+++ b/basic-spring-boot-tekton/.openshift/templates/build.yml
@@ -56,14 +56,14 @@ objects:
       value: ${APPLICATION_SOURCE_REPO}
     - name: revision
       value: ${APPLICATION_SOURCE_REF}
-- apiVersion: tekton.dev/v1alpha1
+- apiVersion: tekton.dev/v1beta1
   kind: Task
   metadata:
     name: maven-build-binary-build
     namespace: ${NAMESPACE}
   spec:
-    inputs:
-      resources:
+    resources:
+      inputs:
       - name: source
         type: git
     steps:   
@@ -97,39 +97,38 @@ objects:
         - ${APPLICATION_NAME}
         - --from-dir
         - "."
-- apiVersion: tekton.dev/v1alpha1
+- apiVersion: tekton.dev/v1beta1
   kind: Task
   metadata:
     name: deploy
     namespace: ${NAMESPACE}
   spec:
-    inputs:
-      params:
-        - name: fromNamespace
-          description: The namespace we are tagging from
-        - name: toNamespace
-          description: The namespace we are tagging to  
-        - name: tag
-          description: The image tag
-        - name: imageStream
-          description: The imageStream
-        - name: deployment
-          description: the deployment                  
+    params:
+      - name: fromNamespace
+        description: The namespace we are tagging from
+      - name: toNamespace
+        description: The namespace we are tagging to  
+      - name: tag
+        description: The image tag
+      - name: imageStream
+        description: The imageStream
+      - name: deployment
+        description: the deployment                  
     steps:
       - name: tag-image
         image: quay.io/openshift-pipeline/openshift-cli:latest
         command: ["/usr/local/bin/oc"]
         args:
           - tag
-          - "$(inputs.params.fromNamespace)/$(inputs.params.imageStream):$(inputs.params.tag)"
-          - "$(inputs.params.toNamespace)/$(inputs.params.imageStream):$(inputs.params.tag)"
+          - "$(params.fromNamespace)/$(params.imageStream):$(params.tag)"
+          - "$(params.toNamespace)/$(params.imageStream):$(params.tag)"
       # not sure what to do here
       - name: verify-deployment
         image: quay.io/openshift-pipeline/openshift-cli:latest
         command: ["sleep"]
         args:
           - "1"                             
-- apiVersion: tekton.dev/v1alpha1
+- apiVersion: tekton.dev/v1beta1
   kind: Pipeline
   metadata:
     name: ${APPLICATION_NAME}-pipeline

--- a/basic-spring-boot-tekton/README.md
+++ b/basic-spring-boot-tekton/README.md
@@ -12,7 +12,7 @@ This example demonstrates how to implement a full end-to-end [Tekton](https://te
   * OpenShift 4.1+ is required
   * [Red Hat OpenJDK 1.8](https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift) image is required
 * Access to GitHub
-* [Tekton Operator](https://github.com/openshift/tektoncd-pipeline-operator) In order to use Tekton pipelines you need to install the Tekton operator. To do that go to ***Catalog***-> ***Operator Hub*** page of you admin console. Look for ***OpenShift Pipelines Operator*** and install it. The default settings are fine for this demo. You can also automate the installation of the Tekton operator, but this is outside the scope of this demo.
+* [Tekton Operator](https://github.com/openshift/tektoncd-pipeline-operator) In order to use Tekton pipelines you need to install the Tekton operator (at least version v1.0.1). To do that go to ***Catalog***-> ***Operator Hub*** page of you admin console. Look for ***OpenShift Pipelines Operator*** and install it. The default settings are fine for this demo. You can also automate the installation of the Tekton operator, but this is outside the scope of this demo.
 * [Tekton CLI](https://github.com/tektoncd/cli)
 * *Highly recommended*: [tekton dashboard](https://github.com/tektoncd/dashboard)
 


### PR DESCRIPTION
#### What does this PR do?
Support for v1beta1 API Version.
Task and Pipeline are impacted, the rest (such as PipelineResource) has not yet been promoted to v1beta1 version.
[Release notes](https://docs.openshift.com/container-platform/4.4/pipelines/op-release-notes.html#new-features-1-0_op-release-notes)

#### How should this be tested?
Manual instruction guide has been used to test this.

#### Is there a relevant Issue open for this?
No issue opened for this.

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
