### PR TITLE
Add better deployment verification instead of the current sleep step

### DIFF
--- a/basic-spring-boot-tekton/.openshift/templates/build.yml
+++ b/basic-spring-boot-tekton/.openshift/templates/build.yml
@@ -112,8 +112,10 @@ objects:
         description: The image tag
       - name: imageStream
         description: The imageStream
+      - name: deploymentResource
+        description: the deployment resource, e.g deployment or deploymentconfig
       - name: deployment
-        description: the deployment                  
+        description: the deployment name
     steps:
       - name: tag-image
         image: quay.io/openshift-pipeline/openshift-cli:latest
@@ -122,12 +124,15 @@ objects:
           - tag
           - "$(params.fromNamespace)/$(params.imageStream):$(params.tag)"
           - "$(params.toNamespace)/$(params.imageStream):$(params.tag)"
-      # not sure what to do here
       - name: verify-deployment
         image: quay.io/openshift-pipeline/openshift-cli:latest
-        command: ["sleep"]
+        command: ["oc"]
         args:
-          - "1"                             
+          - rollout
+          - status
+          - "$(params.deploymentResource)/$(params.deployment)"
+          - -n
+          - "$(params.toNamespace)"
 - apiVersion: tekton.dev/v1beta1
   kind: Pipeline
   metadata:
@@ -158,7 +163,9 @@ objects:
       - name: tag
         value: latest 
       - name: imageStream
-        value: ${APPLICATION_NAME} 
+        value: ${APPLICATION_NAME}
+      - name: deploymentResource
+        value: deploymentconfig
       - name: deployment
         value: ${APPLICATION_NAME}
     - name: deploy-to-stage
@@ -175,6 +182,8 @@ objects:
         value: latest 
       - name: imageStream
         value: ${APPLICATION_NAME} 
+      - name: deploymentResource
+        value: deploymentconfig
       - name: deployment
         value: ${APPLICATION_NAME}
     - name: deploy-to-prod
@@ -190,7 +199,9 @@ objects:
       - name: tag
         value: latest 
       - name: imageStream
-        value: ${APPLICATION_NAME} 
+        value: ${APPLICATION_NAME}
+      - name: deploymentResource
+        value: deploymentconfig
       - name: deployment
         value: ${APPLICATION_NAME}                                           
 - apiVersion: build.openshift.io/v1


### PR DESCRIPTION
#### What does this PR do?
The verify-deployment step was simply a sleep command.
I changed it so use `oc rollout status` so that it waits until the deployment is (un)successful.
Added parameter `deploymentResource` since we can have deployment, deploymentconfig...

#### How should this be tested?
It can be tested by following the manual instructions. And the pipeline logs should indicate the following:
e.g. for the prod project:

> [deploy-to-prod : verify-deployment] Waiting for rollout to finish: 0 out of 1 new replicas have been updated...
> [deploy-to-prod : verify-deployment] Waiting for rollout to finish: 0 out of 1 new replicas have been updated...
> [deploy-to-prod : verify-deployment] Waiting for rollout to finish: 0 out of 1 new replicas have been updated...
> [deploy-to-prod : verify-deployment] Waiting for rollout to finish: 0 out of 1 new replicas have been updated...
> [deploy-to-prod : verify-deployment] Waiting for rollout to finish: 0 of 1 updated replicas are available...
> [deploy-to-prod : verify-deployment] Waiting for latest deployment config spec to be observed by the controller loop...
> [deploy-to-prod : verify-deployment] replication controller "basic-spring-boot-7" successfully rolled out

#### Is there a relevant Issue open for this?
No issue was opened for this.

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
