### PR TITLE
Basic-NGINX: Added Boolean Conversion to String in Jenkinsfile

### DIFF
--- a/basic-nginx/Jenkinsfile
+++ b/basic-nginx/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
     stage('Promotion gate (Stage)') {
       steps {
         script {
-	  if(!("${SKIP_MANUAL_PROMOTION}")) {
+	  if(!("${SKIP_MANUAL_PROMOTION}").toBoolean()) {
             input message: 'Promote Application to Stage?'
           }
         }
@@ -86,7 +86,7 @@ pipeline {
     stage('Promotion gate (Prod)') {
       steps {
         script {
-          if(!("${SKIP_MANUAL_PROMOTION}")) {
+          if(!("${SKIP_MANUAL_PROMOTION}").toBoolean()) {
             input message: 'Promote Application to Prod?'
           }
         }


### PR DESCRIPTION
#### What does this PR do?
This PR corrects an earlier PR in an attempt to add a flag that would allow bypassing the manual promote gate to just do it automatically for automating demos. The earlier PR will skip promotion gate if any value is set for skip_manual_process, which will happen by default since default value is false.

#### How should this be tested?
This should be tested by using the original deploy command for basic-nginx (ansible-playbook -i ./.applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml) where user has to approve promotion in jenkins and running with the command with the flag (ansible-playbook -i ./.applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e skip_manual_promotion=true) where the entire deployment will happen automatically.

#### Is there a relevant Issue open for this?
No.

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
