### PR TITLE
🌲 FIX - broken selector on service and updated nginx image 🌳

### DIFF
--- a/basic-nginx/.openshift/builds/template.yml
+++ b/basic-nginx/.openshift/builds/template.yml
@@ -126,4 +126,4 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: IMAGE_STREAM_TAG_NAME
   required: true
-  value: nginx:1.12
+  value: nginx:1.14

--- a/basic-nginx/.openshift/deployment/template.yml
+++ b/basic-nginx/.openshift/deployment/template.yml
@@ -110,7 +110,6 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      app: ${APPLICATION_NAME}
       deploymentConfig: ${APPLICATION_NAME}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding

--- a/basic-nginx/nginx.conf
+++ b/basic-nginx/nginx.conf
@@ -5,10 +5,10 @@
 
 worker_processes auto;
 error_log stderr;
-pid /var/opt/rh/rh-nginx112/run/nginx/nginx.pid;
+pid /var/opt/rh/rh-nginx114/run/nginx/nginx.pid;
 
-# Load dynamic modules. See /opt/rh/rh-nginx112/root/usr/share/doc/README.dynamic.
-include /opt/rh/rh-nginx112/root/usr/share/nginx/modules/*.conf;
+# Load dynamic modules. See /opt/rh/rh-nginx114/root/usr/share/doc/README.dynamic.
+include /opt/rh/rh-nginx114/root/usr/share/nginx/modules/*.conf;
 
 events {
     worker_connections  1024;
@@ -25,7 +25,7 @@ http {
     keepalive_timeout  65;
     types_hash_max_size 2048;
 
-    include       /etc/opt/rh/rh-nginx112/nginx/mime.types;
+    include       /etc/opt/rh/rh-nginx114/nginx/mime.types;
     default_type  application/octet-stream;
 
     # Load modular configuration files from the /etc/nginx/conf.d directory.


### PR DESCRIPTION
#### What does this PR do?
Two fixes. Happy to raise a PR for each though ;) 
- nginx 112 is deprecated and no longer exists in OpenShift 4.4 so this pipeline will fail. I bumped it to 114
- Since merging https://github.com/redhat-cop/container-pipelines/pull/145 the `app=${APPLICATION_NAME}` selector was removed so the service connection to the pod is broken. This fixes that by only using the deploymentConfig. 

FYI - @etsauer I mentioned this in the Pelorus Dev channel. 

#### How should this be tested?
See README.

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
