### PR TITLE
Update basic-spring-boot pipeline to use namespace names defined via applier

### DIFF
--- a/basic-spring-boot/.applier/group_vars/seed-hosts.yml
+++ b/basic-spring-boot/.applier/group_vars/seed-hosts.yml
@@ -27,6 +27,9 @@ openshift_cluster_content:
     params_from_vars:
       APPLICATION_NAME: "{{ sb_application_name }}"
       NAMESPACE: "{{ sb_build_namespace }}"
+      NAMESPACE_DEV: "{{ sb_dev_namespace }}"
+      NAMESPACE_STAGE: "{{ sb_stage_namespace }}"
+      NAMESPACE_PROD: "{{ sb_prod_namespace }}"
       SOURCE_REPOSITORY_URL: "{{ sb_source_repository_url }}"
       SOURCE_REPOSITORY_REF: "{{ sb_source_repository_ref }}"
       APPLICATION_SOURCE_REPO: "{{ sb_application_repository_url }}"

--- a/basic-spring-boot/.openshift/templates/build.yml
+++ b/basic-spring-boot/.openshift/templates/build.yml
@@ -49,10 +49,20 @@ objects:
       jenkinsPipelineStrategy:
         jenkinsfilePath: ${PIPELINE_SCRIPT}
         env:
+        - name: "APP_NAME"
+          value: "${APPLICATION_NAME}"
         - name: "APPLICATION_SOURCE_REPO"
           value: "${APPLICATION_SOURCE_REPO}"
         - name: "APPLICATION_SOURCE_REF"
           value: "${APPLICATION_SOURCE_REF}"
+        - name: "NAMESPACE_BUILD"
+          value: "${NAMESPACE}"
+        - name: "NAMESPACE_DEV"
+          value: "${NAMESPACE_DEV}"
+        - name: "NAMESPACE_STAGE"
+          value: "${NAMESPACE_STAGE}"
+        - name: "NAMESPACE_PROD"
+          value: "${NAMESPACE_PROD}"
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:
@@ -84,7 +94,7 @@ parameters:
   name: APPLICATION_NAME
   required: true
   value: basic-spring
-- description: The namespace to deploy into
+- description: The namespace that will contain the build resources defined in this template
   name: NAMESPACE
   required: true
 - description: Git source URI for application
@@ -107,6 +117,15 @@ parameters:
 - description: Path within Git project pointing to the pipeline run script
   name: PIPELINE_SCRIPT
   value: Jenkinsfile
+- description: The namespace containing dev resources
+  name: NAMESPACE_DEV
+  required: true
+- description: The namespace containing stage resources
+  name: NAMESPACE_STAGE
+  required: true
+- description: The namespace containing prod resources
+  name: NAMESPACE_PROD
+  required: true
 - description: GitHub trigger secret
   from: '[a-zA-Z0-9]{8}'
   generate: expression

--- a/basic-spring-boot/Jenkinsfile
+++ b/basic-spring-boot/Jenkinsfile
@@ -9,12 +9,11 @@ retriever: modernSCM(
 openshift.withCluster() {
   env.NAMESPACE = openshift.project()
   env.POM_FILE = env.BUILD_CONTEXT_DIR ? "${env.BUILD_CONTEXT_DIR}/pom.xml" : "pom.xml"
-  env.APP_NAME = "${JOB_NAME}".replaceAll(/-build.*/, '')
-  echo "Starting Pipeline for ${APP_NAME}..."
-  env.BUILD = "${env.NAMESPACE}"
-  env.DEV = "${APP_NAME}-dev"
-  env.STAGE = "${APP_NAME}-stage"
-  env.PROD = "${APP_NAME}-prod"
+  echo "Starting Pipeline for ${env.APP_NAME}..."
+  env.BUILD = "${env.NAMESPACE_BUILD}"
+  env.DEV = "${env.NAMESPACE_DEV}"
+  env.STAGE = "${env.NAMESPACE_STAGE}"
+  env.PROD = "${env.NAMESPACE_PROD}"
 }
 
 pipeline {


### PR DESCRIPTION
#### What does this PR do?
Updates to allow the user to change the namespace names of the -build, -dev, -stage, and -prod namespaces. Before this PR, the Jenkinsfile would attempt to derive the application and build names from the -build namespace name, which would fail if applier namespace variables had been changed.

This PR does not address that namespace names are still defined in two places: `.openshift/projects/projects.yml` and `.applier/group_vars/seed-hosts.yml`.

#### How should this be tested?
1. Update the project request resources in `.openshift/projects/projects.yml` by prepending `test-` to all four names
2. Run the applier with additional command line vars to override the default namespace names, and refer to the branch in this PR:
```
ansible-playbook -i ./.applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e sb_build_namespace=test-basic-spring-boot-build -e sb_dev_namespace=test-basic-spring-boot-dev -e sb_stage_namespace=test-basic-spring-boot-stage -e sb_prod_namespace=test-basic-spring-boot-prod -e sb_source_repository_url="https://github.com/bparry02/container-pipelines.git" -e sb_source_repository_ref=135-namespace-names
```
3. Verify the pipeline ran successfully

#### Is there a relevant Issue open for this?
Yes, resolves #135 

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
