### PR TITLE
WIP: Change nginx version to 1.14

### DIFF
--- a/basic-nginx/.applier/group_vars/seed-hosts.yml
+++ b/basic-nginx/.applier/group_vars/seed-hosts.yml
@@ -1,4 +1,4 @@
-source_code_url: https://github.com/kkoller/container-pipelines.git
+source_code_url: https://github.com/redhat-cop/container-pipelines.git
 source_code_ref: master
 skip_manual_promotion: false
 

--- a/basic-nginx/.applier/group_vars/seed-hosts.yml
+++ b/basic-nginx/.applier/group_vars/seed-hosts.yml
@@ -1,4 +1,4 @@
-source_code_url: https://github.com/cop/container-pipelines.git
+source_code_url: https://github.com/kkoller/container-pipelines.git
 source_code_ref: master
 skip_manual_promotion: false
 

--- a/basic-nginx/.applier/group_vars/seed-hosts.yml
+++ b/basic-nginx/.applier/group_vars/seed-hosts.yml
@@ -1,4 +1,4 @@
-source_code_url: https://github.com/redhat-cop/container-pipelines.git
+source_code_url: https://github.com/cop/container-pipelines.git
 source_code_ref: master
 skip_manual_promotion: false
 

--- a/basic-nginx/.applier/group_vars/seed-hosts.yml
+++ b/basic-nginx/.applier/group_vars/seed-hosts.yml
@@ -1,4 +1,4 @@
-source_code_url: https://github.com/redhat-cop/container-pipelines.git
+source_code_url: https://github.com/kkoller/container-pipelines.git
 source_code_ref: master
 skip_manual_promotion: false
 

--- a/basic-nginx/.openshift/builds/template.yml
+++ b/basic-nginx/.openshift/builds/template.yml
@@ -126,4 +126,4 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: IMAGE_STREAM_TAG_NAME
   required: true
-  value: nginx:1.12
+  value: nginx:1.14

--- a/basic-nginx/nginx.conf
+++ b/basic-nginx/nginx.conf
@@ -5,10 +5,10 @@
 
 worker_processes auto;
 error_log stderr;
-pid /var/opt/rh/rh-nginx112/run/nginx/nginx.pid;
+pid /var/opt/rh/rh-nginx114/run/nginx/nginx.pid;
 
 # Load dynamic modules. See /opt/rh/rh-nginx112/root/usr/share/doc/README.dynamic.
-include /opt/rh/rh-nginx112/root/usr/share/nginx/modules/*.conf;
+include /opt/rh/rh-nginx114/root/usr/share/nginx/modules/*.conf;
 
 events {
     worker_connections  1024;

--- a/basic-nginx/nginx.conf
+++ b/basic-nginx/nginx.conf
@@ -7,7 +7,7 @@ worker_processes auto;
 error_log stderr;
 pid /var/opt/rh/rh-nginx114/run/nginx/nginx.pid;
 
-# Load dynamic modules. See /opt/rh/rh-nginx112/root/usr/share/doc/README.dynamic.
+# Load dynamic modules. See /opt/rh/rh-nginx114/root/usr/share/doc/README.dynamic.
 include /opt/rh/rh-nginx114/root/usr/share/nginx/modules/*.conf;
 
 events {
@@ -25,7 +25,7 @@ http {
     keepalive_timeout  65;
     types_hash_max_size 2048;
 
-    include       /etc/opt/rh/rh-nginx112/nginx/mime.types;
+    include       /etc/opt/rh/rh-nginx114/nginx/mime.types;
     default_type  application/octet-stream;
 
     # Load modular configuration files from the /etc/nginx/conf.d directory.


### PR DESCRIPTION
#### What does this PR do?
Nginx 1.12 is not in the cluster by default anymore, so changing this to reference 1.14

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
