### PR TITLE
Update nginx.conf to be compatible with nginx imagestreams on OCP 4.6 +

### DIFF
--- a/basic-nginx/.openshift/builds/template.yml
+++ b/basic-nginx/.openshift/builds/template.yml
@@ -126,4 +126,4 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: IMAGE_STREAM_TAG_NAME
   required: true
-  value: nginx:1.18-ubi8
+  value: nginx:1.16-el8

--- a/basic-nginx/.openshift/builds/template.yml
+++ b/basic-nginx/.openshift/builds/template.yml
@@ -126,4 +126,4 @@ parameters:
 - description: Image stream tag for the image you'd like to use to build the application
   name: IMAGE_STREAM_TAG_NAME
   required: true
-  value: nginx:1.14
+  value: nginx:1.18-ubi8

--- a/basic-nginx/nginx.conf
+++ b/basic-nginx/nginx.conf
@@ -5,10 +5,10 @@
 
 worker_processes auto;
 error_log stderr;
-pid /var/opt/rh/rh-nginx114/run/nginx/nginx.pid;
+pid /run/nginx.pid;
 
-# Load dynamic modules. See /opt/rh/rh-nginx114/root/usr/share/doc/README.dynamic.
-include /opt/rh/rh-nginx114/root/usr/share/nginx/modules/*.conf;
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
 
 events {
     worker_connections  1024;
@@ -25,7 +25,7 @@ http {
     keepalive_timeout  65;
     types_hash_max_size 2048;
 
-    include       /etc/opt/rh/rh-nginx114/nginx/mime.types;
+    include             /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
     # Load modular configuration files from the /etc/nginx/conf.d directory.


### PR DESCRIPTION
#### What does this PR do?
Update nginx.conf to be compatible with latest nginx image stream (nginx:1.18-ubi8) and be able to use this app with pelorus examples

#### How should this be tested?
1. On an OCP 4.6 o later, create a new project

oc new-project nginx-test

2. Create the nginx app using images stream nginx:1.18-ubi8

oc new-app nginx:1.16-el8~https://github.com/fmenesesg/container-pipelines.git --context-dir=/basic-nginx

#### Is there a relevant Issue open for this?
resolves #160 

#### Who would you like to review this?
cc: @redhat-cop/containers-approvers
